### PR TITLE
文件夹名带上帖子的标题

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ thread=2 ;线程数，提高理论上可以增加下载速度。仅支持 1、2�
 page_download_limit=100; 每次下载限制新下载的大约页数。到上限后需要重新运行程序再追加下载，如此直至全部下载成功。允许范围 -1（含）至 100（含）。值为 0 或 -1 时则不限制。默认值 100（约 100 页）。
 
 [post]
-enable_post_title=False ;是否将 .md 文件以标题命名。默认值 False（不启用）
 get_ip_location=False ;是否查询用户基于 IP 的地理位置？若启用则会导致至高 20 倍于未启用的网络请求。默认值 False（不启用）
 enhance_ori_reply=False ;将被回复的楼层内容补充完整。见 issue#35 。开启此功能要求同步将 thread 线程数设置为 1，否则可能会补充到未 format 的文本。默认值 False（不启用）
 ```

--- a/assets/config.ini
+++ b/assets/config.ini
@@ -10,6 +10,5 @@ thread=2 ;线程数，提高理论上可以增加下载速度。仅支持1、2�
 page_download_limit=100; 每次下载限制新下载的大约页数。到上限后需要重新运行程序再追加下载，如此直至全部下载成功。允许范围-1（含）至100（含）。值为0或-1时则不限制。默认值100（约100页）。
 
 [post]
-enable_post_title=False ;是否将.md文件以标题命名。默认值False（不启用）
 get_ip_location=False ;是否查询用户基于IP的地理位置？若启用则会导致至高20倍于未启用的网络请求。默认值False（不启用）
 enhance_ori_reply=False ;将被回复的楼层内容补充完整。见issue#35 。开启此功能要求同步将thread线程数设置为1，否则可能会补充到未format的文本。默认值False（不启用）

--- a/main.go
+++ b/main.go
@@ -63,7 +63,6 @@ func main() {
 	nga.PAGE_DOWNLOAD_LIMIT = cfg.Section("network").Key("page_download_limit").RangeInt(100, -1, 100)
 	nga.GET_IP_LOCATION = cfg.Section("post").Key("get_ip_location").MustBool()
 	nga.ENHANCE_ORI_REPLY = cfg.Section("post").Key("enhance_ori_reply").MustBool()
-	nga.ENABLE_POST_TITLE = cfg.Section("post").Key("enable_post_title").MustBool()
 	nga.Client = nga.NewNgaClient()
 
 	tie := nga.Tiezi{}

--- a/nga/nga.go
+++ b/nga/nga.go
@@ -24,7 +24,6 @@ var (
 	THREAD_COUNT        = 2
 	GET_IP_LOCATION     = false //	获取ip地址
 	ENHANCE_ORI_REPLY   = false //	功能见 #35
-	ENABLE_POST_TITLE   = false //	以帖子标题命名文件 #21
 	PAGE_DOWNLOAD_LIMIT = 100   //	限制单次下载的页数 #56
 	FILENAME            = ""    //  匹配文件夹时的文件夹名字
 	FILEPATH            = ""    //  保存文件时的文件夹名字
@@ -666,7 +665,6 @@ func (tiezi *Tiezi) SaveProcessInfo() {
 	fileName := FILEPATH + `/process.ini`
 	cfg := ini.Empty()
 	cfg.NewSection("local")
-
 	cfg.Section("local").NewKey("max_floor", cast.ToString(tiezi.LocalMaxFloor))
 	cfg.Section("local").NewKey("max_page", cast.ToString(tiezi.LocalMaxPage))
 	cfg.SaveTo(fileName)


### PR DESCRIPTION
标题：修改保存文件标题的方式#21
描述：根据要求，修改保存文件标题的方式，将文件夹名称中添加帖子的标题。如25615215-[其他问题] 关于京东七天无理由退货

修改后逻辑：
- 在第一次生成文件时，下载完成后，修改文件名为tid+标题的方式。
- 后续追加更新时，根据tid匹配文件名后，获取到完整文件夹名，使用第一次修改后也就是获取到的文件夹名（tid+标题）方式进行文件的生成和修改操作。
