### PR TITLE
更换发布页 changelog 生成器

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,35 @@ jobs:
 
       - name: gen changelog
         id: changelog
-        uses: metcalfc/changelog-generator@v4.1.0
+        uses: mikepenz/release-changelog-builder-action@v4.0.0-rc06
         with:
-          myToken: ${{ secrets.GITHUB_TOKEN }}
+          configurationJson: |
+            {
+              "template": "#{{CHANGELOG}}\n\n<details>\n<summary>未归类</summary>\n\n#{{UNCATEGORIZED}}\n</details>",
+              "pr_template": "- #${{NUMBER}} ${{TITLE}} by @${{AUTHOR}}",
+              "categories": [
+                {
+                  "title": "## 🚀 功能",
+                  "labels": ["feature"],
+                  "empty_content": "- 未有相关功能类 PR."
+                },
+                {
+                  "title": "## 🐛 修复",
+                  "labels": ["fix"],
+                  "empty_content": "- 未有相关修复类 PR."
+                },
+                {
+                    "title": "## 💬 其他",
+                    "labels": ["documentation", "other"],
+                    "exhaustive": false
+                }
+              ],
+              "base_branches": [
+                "neo"
+              ]
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
         id: create_release


### PR DESCRIPTION
#68 

为了 release 页面更加简明易懂，计划换用 https://github.com/marketplace/actions/release-changelog-builder 作为 changelog 生成器。此生成器基于 pr 提取信息，要求开发者：

1. 增加新功能时，需要开 issue，并需要再开一个pr， issue 和 pr 均使用 `feature` 标签。
2. 提出、修复 bug 时，可选开 issue，需要开 pr，使用 `fix` 标签。
3. 比较重要的文档或者其余，想上 release 页面的更改，可选开 issue，需要开 pr，使用 `documentation` 或者 `other` 标签。
4. 不重要的文档或其余更改，且不想上 release 页面，可选开 issue，不能开 pr，可直接推 neo 分支。