### PR TITLE
支持 force-no-check-update、dump-update-info、version、help、gen-config-file 等参数

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/') #在打tag时候触发
     runs-on: ubuntu-latest
     steps:
+    - name: Set timezone
+      uses: szenius/set-timezone@v1.2
+      with:
+        timezoneLinux: "Asia/Shanghai"
+        timezoneMacos: "Asia/Shanghai"
+        timezoneWindows: "China Standard Time"
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -84,6 +91,11 @@ jobs:
         strip_v: true # Optional: Remove 'v' character from version
         default: v0.0.0 # Optional: Default version when tag not found
 
+    - name: Set BUILD_TS env
+      run: echo BUILD_TS=$(date +%s) >> ${GITHUB_ENV}
+    - name: Environment Printer
+      uses: managedkaos/print-env@v1.0
+
     - uses: wangyoucao577/go-release-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -92,6 +104,6 @@ jobs:
         goarch: ${{ matrix.goarch }}
         md5sum: FALSE
         extra_files: LICENSE README.md assets/* #将这些文件一并打包
-        ldflags: -X github.com/ludoux/ngapost2md/nga.DEBUG_MODE=0
+        ldflags: -X "github.com/ludoux/ngapost2md/nga.DEBUG_MODE=0" -X "github.com/ludoux/ngapost2md/nga.BUILD_TS==${{ env.BUILD_TS }}" -X github.com/ludoux/ngapost2md/nga.GIT_REF=${{ github.ref }} -X github.com/ludoux/ngapost2md/nga.GIT_HASH=${{ github.sha }}
         overwrite: TRUE #若已有附件则覆写
         asset_name: ngapost2md-NEO_${{ steps.tag.outputs.tag }}-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab // indirect
+	github.com/jessevdk/go-flags v1.5.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0 // indirect
 	github.com/orirawlings/persistent-cookiejar v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/imroc/req/v3 v3.35.0 h1:JDtg+sFB0HVc4S3TcAsm7Mf7rsiwf4f/edAlYDAGg8Q=
 github.com/imroc/req/v3 v3.35.0/go.mod h1:zWuou7ZZtPLp/gmMj58jARgZuhKlEdb2gLxDeNfWpCA=
 github.com/imroc/req/v3 v3.38.0 h1:HpUrW3evLgy3XGyJ4kyIdMAYNagaMzNAeqyWS8XaTeM=
 github.com/imroc/req/v3 v3.38.0/go.mod h1:4wMbz0QYY5jmXNWk0BsWrRTR9ItZqOxzSJdGL0M9kzY=
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -268,6 +270,7 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -5,45 +5,118 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/imroc/req/v3"
+	"github.com/jessevdk/go-flags"
 	"github.com/ludoux/ngapost2md/config"
 	"github.com/ludoux/ngapost2md/nga"
 	"github.com/spf13/cast"
 )
 
+type Option struct {
+	ForceNoCheckUpdate bool `long:"force-no-check-update" description:"在编译时间后的不少于 60 天内，不检测版本更新。"`
+	DumpUpdateInfo     bool `long:"dump-update-info" description:"当检测到新版本时，将版本信息原始文件写入 NEED_UPDATE 文件。"`
+	Version            bool `short:"v" long:"version" description:"显示版本信息并退出"`
+	Help               bool `short:"h" long:"help" description:"显示此帮助信息并退出"`
+	GenConfigFile      bool `long:"gen-config-file" description:"生成默认配置文件于 config.ini 并退出"`
+}
+
+func checkUpdate(dump bool) {
+	resp, _ := req.C().R().Get("https://gitee.com/ludoux/check-update/raw/master/ngapost2md/version_neo.txt")
+	//版本更新配置文件改为 DO_NOT_CHECK ，软件则不会强制使用最新版本
+	if resp.String() != nga.VERSION && resp.String() != "DO_NOT_CHECK" {
+		if dump {
+			f, _ := os.OpenFile("NEED_UPDATE", os.O_CREATE|os.O_WRONLY, 0666)
+			_, _ = f.Write(resp.Bytes())
+			defer f.Close()
+		}
+		log.Printf("目前版本: %s 最新版本: %s", nga.VERSION, resp.String())
+		log.Fatalln("请去 GitHub Releases 页面下载最新版本。软件即将退出……")
+	}
+}
+
 func main() {
-	fmt.Printf("ngapost2md (c) ludoux [ GitHub: https://github.com/ludoux/ngapost2md/tree/neo ]\nVersion: %s\n", nga.VERSION)
-	if nga.DEBUG_MODE == "1" {
-		fmt.Println("***DEBUG MODE ON***")
+	var opts Option
+	parser := flags.NewParser(&opts, flags.Default & ^flags.HelpFlag)
+	//args为剩余未解析的（比如tid）
+	args, err := parser.Parse()
+	if err != nil {
+		log.Fatalln("参数解析出现问题:", err.Error())
 	}
-	if len(os.Args) != 2 {
-		log.Fatalln("传参数目错误！请使用 ngapost2md -h 命令查看 ngapost2md 的使用参数说明。")
-	}
-	if len(os.Args) == 2 && (cast.ToString(os.Args[1]) == "help" || cast.ToString(os.Args[1]) == "-help" || cast.ToString(os.Args[1]) == "--help" || cast.ToString(os.Args[1]) == "-h") {
-		fmt.Println("使用: ngapost2md tid")
-		fmt.Println("选项与参数说明: ")
-		fmt.Println("tid: 待下载的帖子 tid 号")
-		fmt.Println("")
-		fmt.Println("ngapost2md --gen-config-file : 可生成默认配置文件于 config.ini")
+
+	if opts.Version {
+		fmt.Println("ngapost2md", nga.VERSION)
+		fmt.Println("Build_Time:", nga.BUILD_TS, time.Unix(cast.ToInt64(nga.BUILD_TS), 0).Local().Format("2006-01-02T15:04:05Z07:00"))
+		fmt.Println("Git_Ref:", nga.GIT_REF)
+		fmt.Println("Git_Hash:", nga.GIT_HASH)
 		os.Exit(0)
-	}
-	if len(os.Args) == 2 && (cast.ToString(os.Args[1]) == "--gen-config-file") {
+	} else if opts.GenConfigFile {
 		err := config.SaveDefaultConfigFile()
 		if err != nil {
 			log.Fatalln(err.Error())
 		}
 		log.Println("导出默认配置文件 config.ini 成功。")
 		os.Exit(0)
+	} else if opts.Help {
+		fmt.Println("使用: ngapost2md tid [--force-no-check-update] [--dump-update-info]")
+		fmt.Println("选项与参数说明: ")
+		fmt.Println("tid: 待下载的帖子 tid 号")
+		fmt.Println("--force-no-check-update     ", parser.FindOptionByLongName("force-no-check-update").Description)
+		fmt.Println("--dump-update-info          ", parser.FindOptionByLongName("dump-update-info").Description)
+		fmt.Println("")
+		fmt.Println("ngapost2md -v, --version    ", parser.FindOptionByLongName("version").Description)
+		fmt.Println("ngapost2md -h, --help       ", parser.FindOptionByLongName("help").Description)
+		fmt.Println("ngapost2md --gen-config-file", parser.FindOptionByLongName("gen-config-file").Description)
+		os.Exit(0)
 	}
 
-	//DEBUG_MODE不为1时（不是DEBUG_MODE）时检测更新
-	if nga.DEBUG_MODE != "1" {
-		resp, _ := req.C().R().Get("https://gitee.com/ludoux/check-update/raw/master/ngapost2md/version_neo.txt")
-		//版本更新配置文件改为 DO_NOT_CHECK ，软件则不会强制使用最新版本
-		if resp.String() != nga.VERSION && resp.String() != "DO_NOT_CHECK" {
-			log.Printf("目前版本: %s 最新版本: %s", nga.VERSION, resp.String())
-			log.Fatalln("请去 GitHub Releases 页面下载最新版本。软件即将退出……")
+	var tid int
+	if len(args) != 1 {
+		log.Fatalln("未传入 tid 或格式错误")
+	} else {
+		tid, err = cast.ToIntE(args[0])
+		if err != nil {
+			log.Fatalln("tid", args[0], "无法转为数字:", err.Error())
+		}
+	}
+
+	//args check all passed
+
+	fmt.Printf("ngapost2md (c) ludoux [ GitHub: https://github.com/ludoux/ngapost2md/tree/neo ]\nVersion: %s     %s\n", nga.VERSION, time.Unix(cast.ToInt64(nga.BUILD_TS), 0).Local().Format("2006-01-02T15:04:05Z07:00"))
+	if nga.DEBUG_MODE == "1" {
+		fmt.Println("==debug mode===")
+		fmt.Println("***DEBUG MODE ON***")
+		fmt.Printf("opts: %+v ; args: %v\n", opts, args)
+		fmt.Println("==debug mode===")
+	}
+
+	//DEBUG_MODE不为1时(不是DEBUG_MODE)情况下，未有 ForceNoCheckUpdate 时检测更新
+	if nga.DEBUG_MODE == "1" {
+		fmt.Println("==debug mode===")
+		fmt.Println("DEBUG MODE 下恒不检查更新")
+		fmt.Println("==debug mode===")
+	} else {
+		if !opts.ForceNoCheckUpdate {
+			checkUpdate(opts.DumpUpdateInfo)
+		} else {
+			//如果有这个标，在大于指定天数后也要检查更新
+			curTs := time.Now().Local().Unix()
+			builtTs, err := cast.ToInt64E(nga.BUILD_TS)
+			if err != nil {
+				log.Fatalln("BUILD_TS", nga.BUILD_TS, "无法转为数字，可能编译时 ldflags 有误")
+			}
+
+			if curTs < builtTs {
+				fmt.Println("由于本地时间有误，仍将检查更新。")
+				checkUpdate(opts.DumpUpdateInfo)
+			} else if curTs-builtTs > 61*86400 {
+				//61天
+				fmt.Println("距离此版本编译时间已过去", (curTs-builtTs)/86400, "天，仍将检查更新。")
+				checkUpdate(opts.DumpUpdateInfo)
+			} else {
+				fmt.Println("由于使用了 --force-no-check-update 标志，且距离编译时间仍在时限内，本次不检查更新。距离此版本编译时间已过", (curTs-builtTs)/86400, "天")
+			}
 		}
 	}
 	// 检查并更新配置文件
@@ -77,10 +150,6 @@ func main() {
 
 	tie := nga.Tiezi{}
 
-	tid, err := cast.ToIntE(os.Args[1])
-	if err != nil {
-		log.Fatalln("tid 无法转为数字:", err.Error())
-	}
 	path := nga.FindFolderNameByTid(tid)
 	if path != "" {
 		log.Printf("本地存在此 tid (%s) 文件夹，追加最新更改。", path)

--- a/nga/nga.go
+++ b/nga/nga.go
@@ -37,7 +37,10 @@ var (
 
 // 这里配置文件和传参都没法改
 var (
-	VERSION  = "NEO_1.4.2"
+	VERSION  = "NEO_1.4.2"  //需要手动改
+	BUILD_TS = "1691664141" //无需，GitHub actions会自动填写
+	GIT_REF  = ""           //无需，GitHub actions会自动填写
+	GIT_HASH = ""           //无需，GitHub actions会自动填写
 	DELAY_MS = 330
 	mutex    sync.Mutex
 )


### PR DESCRIPTION
```
> ngapost2md -h

使用: ngapost2md tid [--force-no-check-update] [--dump-update-info]
选项与参数说明: 
tid: 待下载的帖子 tid 号
--force-no-check-update      在编译时间后的不少于 60 天内，不检测版本更新。
--dump-update-info           当检测到新版本时，将版本信息原始文件写入 NEED_UPDATE 文件。

ngapost2md -v, --version     显示版本信息并退出
ngapost2md -h, --help        显示此帮助信息并退出
ngapost2md --gen-config-file 生成默认配置文件于 config.ini 并退出
```

为 #73 引入 `--force-no-check-update`。仅会在编译时间之后的不少于 60 天内有效。 closes #73 
为 #71 引入 `--dump-update-info`。若更新检查中检测到新版本，会生成 `NEED_UPDATE` 文件。文件内容不保证格式。closes #71 
`--gen-config-file` 主要测试用

其它都是应该有（但没有的）